### PR TITLE
docs(github-label-sync): fix doc inaccuracies and add workflow timeout

### DIFF
--- a/.github/actions/github-label-sync-action/action.yaml
+++ b/.github/actions/github-label-sync-action/action.yaml
@@ -5,7 +5,7 @@ inputs:
     default: "false"
     description: Allow additional labels in the repository, and don't delete them.
     required: false
-  github_token:
+  gh_token:
     default: ${{ github.token }}
     description: GitHub access token to sync labels.
     required: false
@@ -22,7 +22,7 @@ runs:
   steps:
     - uses: actions/checkout@v6
       with:
-        token: ${{ inputs.github_token }}
+        token: ${{ inputs.gh_token }}
         repository: ${{ inputs.source_repository }}
         sparse-checkout: .github/labels
         path: .label-source
@@ -45,7 +45,7 @@ runs:
       with:
         config-file: ${{ steps.merge.outputs.config_file }}
         delete-other-labels: ${{ inputs.allow_added_labels == 'false' }}
-        token: ${{ inputs.github_token }}
+        token: ${{ inputs.gh_token }}
 branding:
   color: orange
   icon: refresh-cw

--- a/.github/workflows/github-label-sync.yaml
+++ b/.github/workflows/github-label-sync.yaml
@@ -19,7 +19,7 @@ on:
         required: false
         type: boolean
     secrets:
-      github_token:
+      gh_token:
         description: |
           GitHub access token to sync labels. Defaults to github.token if not provided.
           Required when source_repository is a private repository other than the caller.
@@ -32,10 +32,11 @@ permissions:
 jobs:
   sync:
     runs-on: ubuntu-slim
+    timeout-minutes: 5
     steps:
       - uses: yuzu441/workflows/.github/actions/github-label-sync-action@main
         with:
           source_paths: ${{ inputs.source_paths }}
           source_repository: ${{ inputs.source_repository }}
           allow_added_labels: ${{ inputs.allow_added_labels }}
-          github_token: ${{ secrets.github_token || github.token }}
+          gh_token: ${{ secrets.gh_token || github.token }}

--- a/doc/github-label-sync-action.md
+++ b/doc/github-label-sync-action.md
@@ -10,15 +10,15 @@ GitHubリポジトリのラベルをYAMLファイルで定義し、同期するr
 
 | 名前 | デフォルト | 型 | 説明 |
 |------|-----------|-----|------|
-| `source_paths` | `.github/labels/labels.yaml` | string | 適用するラベル定義ファイルのパス（改行区切りで複数指定可能）。複数指定した場合は順番に結合される |
-| `source_repository` | `yuzu441/workflows` | string | ラベル定義ファイルを取得するリポジトリ |
+| `source_paths` | `.github/labels/labels.yaml` | string | `source_repository` の `.github/labels/` 配下にあるラベル定義ファイルパス（改行区切りで複数指定可能）。複数指定した場合は順番に結合される |
+| `source_repository` | `yuzu441/workflows` | string | `source_paths` のパスを解決するリポジトリ |
 | `allow_added_labels` | `false` | boolean | `true` にすると、定義ファイルに存在しないラベルをリポジトリから削除しない |
 
 ## Secrets
 
 | 名前 | 必須 | 説明 |
 |------|------|------|
-| `github_token` | 任意 | ラベルを同期するためのGitHubトークン。未指定の場合は `github.token` を使用。`source_repository` が別のプライベートリポジトリの場合は必須 |
+| `gh_token` | 任意 | ラベルを同期するためのGitHubトークン。未指定の場合は `github.token` を使用。`source_repository` が別のプライベートリポジトリの場合は必須 |
 
 ## 利用例
 
@@ -52,7 +52,6 @@ name: github-label-sync
 on:
   push:
     paths:
-      - .github/labels/**
       - .github/workflows/github-label-sync.yaml
   workflow_dispatch:
 
@@ -72,7 +71,7 @@ jobs:
 
 ## ラベルファイルの構成
 
-ラベル定義ファイルは `.github/labels/` ディレクトリに配置します。
+`yuzu441/workflows` リポジトリで管理しているラベル定義ファイルは以下の通りです。
 
 | ファイル | 内容 |
 |---------|------|


### PR DESCRIPTION
- source_paths の説明に「source_repository 内のパス」と明記
- source_repository の説明をパス解決の基準として明確化
- 完全なワークフロー例のトリガーから .github/labels/** を削除
  （source_paths は source_repository 内を参照するため、呼び出し元の
   labels/** 変更を監視しても意味がなかった）
- ラベルファイルの構成セクションが yuzu441/workflows の話であることを明記
- github-label-sync workflow に timeout-minutes: 5 を追加
